### PR TITLE
Allow the loading of lora_stack without lora_name

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -88,7 +88,7 @@ class TSC_EfficientLoader:
         # Retrieve cache numbers
         vae_cache, ckpt_cache, lora_cache = get_cache_numbers("Efficient Loader")
 
-        if lora_name != "None" or lora_stack is not None:
+        if lora_name != "None" or lora_stack:
             # Initialize an empty list to store LoRa parameters.
             lora_params = []
 

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -100,9 +100,9 @@ class TSC_EfficientLoader:
             if lora_stack:
                 lora_params.extend(lora_stack)
 
-            # If there are any parameters in lora_params, load the LoRa with them.
-            if lora_params:
-                model, clip = load_lora(lora_params, ckpt_name, my_unique_id, cache=lora_cache, ckpt_cache=ckpt_cache, cache_overwrite=True)
+            # Load LoRa(s)
+            model, clip = load_lora(lora_params, ckpt_name, my_unique_id, cache=lora_cache, ckpt_cache=ckpt_cache, cache_overwrite=True)
+
             if vae_name == "Baked VAE":
                 vae = get_bvae_by_ckpt_name(ckpt_name)
         else:

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -89,12 +89,20 @@ class TSC_EfficientLoader:
         vae_cache, ckpt_cache, lora_cache = get_cache_numbers("Efficient Loader")
 
         if lora_name != "None" or lora_stack is not None:
+            # Initialize an empty list to store LoRa parameters.
             lora_params = []
+
+            # Check if lora_name is not the string "None" and if so, add its parameters.
             if lora_name != "None":
                 lora_params.append((lora_name, lora_model_strength, lora_clip_strength))
-            if lora_stack is not None:
+
+            # If lora_stack is not None or an empty list, extend lora_params with its items.
+            if lora_stack:
                 lora_params.extend(lora_stack)
-            model, clip = load_lora(lora_params, ckpt_name, my_unique_id, cache=lora_cache, ckpt_cache=ckpt_cache, cache_overwrite=True)
+
+            # If there are any parameters in lora_params, load the LoRa with them.
+            if lora_params:
+                model, clip = load_lora(lora_params, ckpt_name, my_unique_id, cache=lora_cache, ckpt_cache=ckpt_cache, cache_overwrite=True)
             if vae_name == "Baked VAE":
                 vae = get_bvae_by_ckpt_name(ckpt_name)
         else:

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -88,8 +88,10 @@ class TSC_EfficientLoader:
         # Retrieve cache numbers
         vae_cache, ckpt_cache, lora_cache = get_cache_numbers("Efficient Loader")
 
-        if lora_name != "None":
-            lora_params = [(lora_name, lora_model_strength, lora_clip_strength)]
+        if lora_name != "None" or lora_stack is not None:
+            lora_params = []
+            if lora_name != "None":
+                lora_params.append((lora_name, lora_model_strength, lora_clip_strength))
             if lora_stack is not None:
                 lora_params.extend(lora_stack)
             model, clip = load_lora(lora_params, ckpt_name, my_unique_id, cache=lora_cache, ckpt_cache=ckpt_cache, cache_overwrite=True)


### PR DESCRIPTION
This small change allows you to use `lora_stack` on the `Efficient Loader` block even when you set `Lora` to "None".
It is a very small change, but it solves a small inconvencience I ran into.

It will also be put into the dependencies output, which is important for certain XY situations.

![image](https://github.com/LucianoCirino/efficiency-nodes-comfyui/assets/3903469/06c32add-e41a-4236-a44c-c671119b6e82)
