### PR TITLE
simpleeval-fix

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -42,6 +42,9 @@ import comfy.latent_formats
 # Import my library
 from tsc_utils import *
 
+# Import dependencies
+from simpleeval import simple_eval
+
 MAX_RESOLUTION=8192
 
 ########################################################################################################################


### PR DESCRIPTION
Mistakenly removed the importing of the simpleeval package from "efficiency_nodes.py"