### PR TITLE
Implement fallback for pip installations

### DIFF
--- a/tsc_utils.py
+++ b/tsc_utils.py
@@ -470,22 +470,31 @@ def install_packages(my_dir):
     target_dir = os.path.abspath(os.path.join(my_dir, '..', '..', '..', 'python_embeded', 'Lib', 'site-packages'))
     embedded_python_exe = os.path.abspath(os.path.join(my_dir, '..', '..', '..', 'python_embeded', 'python.exe'))
 
+    # If embedded_python_exe exists, target the installations. Otherwise, go untargeted.
+    use_embedded = os.path.exists(embedded_python_exe)
+
     # Load packages from requirements.txt
     with open(os.path.join(my_dir, 'requirements.txt'), 'r') as f:
         required_packages = [line.strip() for line in f if line.strip()]
 
-    installed_packages = packages(embedded_python_exe, versions=False)
+    installed_packages = packages(embedded_python_exe if use_embedded else None, versions=False)
     for pkg in required_packages:
         if pkg not in installed_packages:
             print(f"\033[32mEfficiency Nodes:\033[0m Installing required package '{pkg}'...", end='', flush=True)
-            subprocess.check_call(['pip', 'install', pkg, '--target=' + target_dir, '--no-warn-script-location',
-                                   '--disable-pip-version-check'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if use_embedded:  # Targeted installation
+                subprocess.check_call(['pip', 'install', pkg, '--target=' + target_dir, '--no-warn-script-location',
+                                       '--disable-pip-version-check'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            else:  # Untargeted installation
+                subprocess.check_call(['pip', 'install', pkg], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             print(f"\r\033[32mEfficiency Nodes:\033[0m Installing required package '{pkg}'... Installed!", flush=True)
 
-def packages(python_exe, versions=False):
-    # Get packages of the embedded Python environment
-    return [(r.decode().split('==')[0] if not versions else r.decode()) for r in
-            subprocess.check_output([python_exe, '-m', 'pip', 'freeze']).split()]
+def packages(python_exe=None, versions=False):
+    # Get packages of the active or embedded Python environment
+    if python_exe:
+        return [(r.decode().split('==')[0] if not versions else r.decode()) for r in
+                subprocess.check_output([python_exe, '-m', 'pip', 'freeze']).split()]
+    else:
+        return [(r.split('==')[0] if not versions else r) for r in subprocess.getoutput('pip freeze').splitlines()]
 
 # Install missing packages
 install_packages(my_dir)


### PR DESCRIPTION
This commit introduces a fallback mechanism for the package installation process. 

- If the `python_embedded` directory is not found, the installation defaults to the current Python environment.
- This ensures that packages are installed successfully regardless of the setup, enhancing compatibility across different machines.