### PR TITLE
Fix TypeError in tsc_utils.py related to type hinting

### DIFF
--- a/tsc_utils.py
+++ b/tsc_utils.py
@@ -9,6 +9,7 @@ import io
 from contextlib import contextmanager
 import json
 import folder_paths
+from typing import Dict, List
 
 # Get the absolute path of the parent directory of the current script
 my_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This pull request addresses the TypeError we were facing when trying to use indexing or subscription on an object that doesn't support it. The problem was due to the way we were type hinting dictionaries before Python 3.9.

Changes:
Imported necessary classes (Dict and List) from the typing module. Updated the type hint for last_helds to use Dict and List.