### PR TITLE
XY Input: Checkpoint "+VAE" input_mode Fix

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -173,6 +173,7 @@ function handleVisibility(node, countValue, mode) {
                 }
             } else if (inputModeValue.includes("Names+Weights") || inputModeValue.includes("+ClipSkip")) {
                 toggleWidget(node, firstWidget, true);
+                if (inputModeValue.includes("+VAE")){toggleWidget(node, secondWidget, true);}
             }
             if (!inputModeValue.includes("Names") && mode !== "LoRA Stacker") {
                 toggleWidget(node, secondWidget, true);


### PR DESCRIPTION
Fixed an issue where adding Checkpoints would not add the VAE option for when input mode was set to "Ckpt Names+ClipSkip+VAE"