### PR TITLE
fix: XY Plot accumulation bug fix about XY Capsule

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -1518,10 +1518,11 @@ class TSC_KSampler:
 
                 elif X_type != "Nothing" and Y_type != "Nothing":
                     for Y_index, Y in enumerate(Y_value):
-
-                        if Y_type == "XY_Capsule" and X_type == "XY_Capsule":
+                        if Y_type == "XY_Capsule" or X_type == "XY_Capsule":
                             model, clip, refiner_model, refiner_clip = \
                                 clone_or_none(original_model, original_clip, original_refiner_model, original_refiner_clip)
+
+                        if Y_type == "XY_Capsule" and X_type == "XY_Capsule":
                             Y.set_x_capsule(X)
 
                         # Define Y parameters and generate labels


### PR DESCRIPTION
Problem:
When there is only one axis is `XY capsule` and the others axis is `seed++`, it results in an accumulation effect of model transformations.

Affected code:
```
                        if Y_type == "XY_Capsule":
                            model, clip, vae = Y.pre_define_model(model, clip, vae)
                        elif X_type == "XY_Capsule":
                            model, clip, vae = X.pre_define_model(model, clip, vae)
```
