### PR TITLE
Optional ControlNet Stack

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -358,8 +358,8 @@ class TSC_Apply_ControlNet_Stack:
     @classmethod
     def INPUT_TYPES(cls):
         return {"required": {"positive": ("CONDITIONING",),
-                             "negative": ("CONDITIONING",),
-                             "cnet_stack": ("CONTROL_NET_STACK",)},
+                             "negative": ("CONDITIONING",)},
+                "optional": {"cnet_stack": ("CONTROL_NET_STACK",)}
                 }
 
     RETURN_TYPES = ("CONDITIONING","CONDITIONING",)
@@ -367,7 +367,10 @@ class TSC_Apply_ControlNet_Stack:
     FUNCTION = "apply_cnet_stack"
     CATEGORY = "Efficiency Nodes/Stackers"
 
-    def apply_cnet_stack(self, positive, negative, cnet_stack):
+    def apply_cnet_stack(self, positive, negative, cnet_stack=None):
+        if cnet_stack is None:
+            return (positive, negative)
+
         for control_net_tuple in cnet_stack:
             control_net, image, strength, start_percent, end_percent = control_net_tuple
             controlnet_conditioning = ControlNetApplyAdvanced().apply_controlnet(positive, negative,


### PR DESCRIPTION
I believe that making the ControlNet Stack optional in the `Apply ControlNet Stack` node would be a good addition. In my use case, I found it beneficial while working with the [ComfyUI-Workflow-Component](https://github.com/ltdrdata/ComfyUI-Workflow-Component/) and applying a ControlNet stack without using the `Efficiency Loader` node.
